### PR TITLE
💄 (ui): Updated new entry button

### DIFF
--- a/frontend/apps/slip-snapper/src/app/Tests/__snapshots__/App.spec.tsx.snap
+++ b/frontend/apps/slip-snapper/src/app/Tests/__snapshots__/App.spec.tsx.snap
@@ -14,6 +14,27 @@ exports[`TakePicture Button component Matches the snapshot of the TakePicture bu
         icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' class='ionicon' viewBox='0 0 512 512'><title>Receipt</title><path d='M483.82 32.45a16.28 16.28 0 00-11.23 1.37L448 46.1l-24.8-12.4a16 16 0 00-14.31 0l-25.11 12.41L359 33.7a16 16 0 00-14.36 0L320 46.07l-24.45-12.34a16 16 0 00-14.35-.06L256 46.12l-24.8-12.43a16.05 16.05 0 00-14.33 0L192 46.1l-24.84-12.41a16 16 0 00-19.36 3.94 16.25 16.25 0 00-3.8 10.65V288l.05.05H336a32 32 0 0132 32V424c0 30.93 33.07 56 64 56h12a52 52 0 0052-52V48a16 16 0 00-12.18-15.55zM416 240H288.5c-8.64 0-16.1-6.64-16.48-15.28A16 16 0 01288 208h127.5c8.64 0 16.1 6.64 16.48 15.28A16 16 0 01416 240zm0-80H224.5c-8.64 0-16.1-6.64-16.48-15.28A16 16 0 01224 128h191.5c8.64 0 16.1 6.64 16.48 15.28A16 16 0 01416 160z'/><path d='M336 424v-88a16 16 0 00-16-16H48a32.1 32.1 0 00-32 32.05c0 50.55 5.78 71.57 14.46 87.57C45.19 466.79 71.86 480 112 480h245.68a4 4 0 002.85-6.81C351.07 463.7 336 451 336 424z'/></svg>"
       />
     </ion-fab-button>
+    <ion-fab-list
+      side="top"
+    >
+      <ion-fab-button
+        onClick={[Function]}
+      >
+        <ion-icon
+          icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' class='ionicon' viewBox='0 0 512 512'><title>Camera</title><circle cx='256' cy='272' r='64'/><path d='M432 144h-59c-3 0-6.72-1.94-9.62-5l-25.94-40.94a15.52 15.52 0 00-1.37-1.85C327.11 85.76 315 80 302 80h-92c-13 0-25.11 5.76-34.07 16.21a15.52 15.52 0 00-1.37 1.85l-25.94 41c-2.22 2.42-5.34 5-8.62 5v-8a16 16 0 00-16-16h-24a16 16 0 00-16 16v8h-4a48.05 48.05 0 00-48 48V384a48.05 48.05 0 0048 48h352a48.05 48.05 0 0048-48V192a48.05 48.05 0 00-48-48zM256 368a96 96 0 1196-96 96.11 96.11 0 01-96 96z'/></svg>"
+          onClick={[Function]}
+        />
+      </ion-fab-button>
+      <ion-fab-button
+        href="/addentry"
+        onClick={[Function]}
+        router-link="/addentry"
+      >
+        <ion-icon
+          icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' class='ionicon' viewBox='0 0 512 512'><title>List</title><path stroke-linecap='round' stroke-linejoin='round' stroke-width='48' d='M160 144h288M160 256h288M160 368h288' class='ionicon-fill-none'/><circle cx='80' cy='144' r='16' stroke-linecap='round' stroke-linejoin='round' class='ionicon-fill-none ionicon-stroke-width'/><circle cx='80' cy='256' r='16' stroke-linecap='round' stroke-linejoin='round' class='ionicon-fill-none ionicon-stroke-width'/><circle cx='80' cy='368' r='16' stroke-linecap='round' stroke-linejoin='round' class='ionicon-fill-none ionicon-stroke-width'/></svg>"
+        />
+      </ion-fab-button>
+    </ion-fab-list>
   </ion-fab>
 </ion-content>
 `;

--- a/frontend/apps/slip-snapper/src/app/Tests/__snapshots__/App.spec.tsx.snap
+++ b/frontend/apps/slip-snapper/src/app/Tests/__snapshots__/App.spec.tsx.snap
@@ -8,6 +8,7 @@ exports[`TakePicture Button component Matches the snapshot of the TakePicture bu
     vertical="bottom"
   >
     <ion-fab-button
+      color="secondary"
       onClick={[Function]}
     >
       <ion-icon

--- a/frontend/apps/slip-snapper/src/app/components/Budget.tsx
+++ b/frontend/apps/slip-snapper/src/app/components/Budget.tsx
@@ -1,7 +1,5 @@
 import {
     IonAlert,
-    IonButton,
-    IonFab,
     IonIcon,
     IonInput,
     IonItem,

--- a/frontend/apps/slip-snapper/src/app/components/EditBudgets.tsx
+++ b/frontend/apps/slip-snapper/src/app/components/EditBudgets.tsx
@@ -44,7 +44,7 @@ export const EditBudgets = () => {
               <IonButton onClick={() => {
                 setIsOpen(false);
                 hideData(categoryStates)
-              }}>Confirm</IonButton>
+              }}>Close</IonButton>
             </IonButtons>
           </IonToolbar>
         </IonHeader>

--- a/frontend/apps/slip-snapper/src/app/components/TakePictureButton.tsx
+++ b/frontend/apps/slip-snapper/src/app/components/TakePictureButton.tsx
@@ -1,9 +1,10 @@
-import { receipt } from 'ionicons/icons';
+import { receipt, camera, list } from 'ionicons/icons';
 import { usePhotoGallery } from '../../hooks/usePhotoGallery';
 import {
   IonContent,
   IonFab,
   IonFabButton,
+  IonFabList,
   IonIcon,
 } from '@ionic/react';
 import React from 'react';
@@ -16,9 +17,17 @@ const TakePictureButton: React.FC = () => {
   return (
     <IonContent>
         <IonFab horizontal ="center" vertical="bottom" slot="fixed" className='takePicture'>
-        <IonFabButton onClick={usePhotoGallery}>
+        <IonFabButton >
           <IonIcon icon={receipt}></IonIcon>
         </IonFabButton>
+        <IonFabList side="top">
+            <IonFabButton>
+              <IonIcon icon={camera} onClick={usePhotoGallery}></IonIcon>
+            </IonFabButton>
+            <IonFabButton routerLink={"/addentry"}>
+              <IonIcon icon={list}></IonIcon>
+            </IonFabButton>
+          </IonFabList>
       </IonFab>
     </IonContent>
   );

--- a/frontend/apps/slip-snapper/src/app/components/TakePictureButton.tsx
+++ b/frontend/apps/slip-snapper/src/app/components/TakePictureButton.tsx
@@ -17,7 +17,7 @@ const TakePictureButton: React.FC = () => {
   return (
     <IonContent>
         <IonFab horizontal ="center" vertical="bottom" slot="fixed" className='takePicture'>
-        <IonFabButton >
+        <IonFabButton color='secondary'>
           <IonIcon icon={receipt}></IonIcon>
         </IonFabButton>
         <IonFabList side="top">


### PR DESCRIPTION
Added options to either upload image or enter receipt details manually for floating action button on home page